### PR TITLE
Cropping holograms to a square by default

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -82,4 +82,4 @@ Now you're ready to reconstruct your holograms!
 
 For more tutorials, see the Tutorials documentation.
 
-:ref:`Return to Top <_getting_started>`
+:ref:`Return to Top <getting_started>`

--- a/shampoo/reconstruction.py
+++ b/shampoo/reconstruction.py
@@ -136,6 +136,19 @@ def _crop_image(image, crop_fraction):
     return cropped_image
 
 
+def _crop_to_square(image):
+    """
+    Ensure that hologram is square.
+    """
+    sh = image.shape
+    if sh[0] != sh[1]:
+        square_image = image[:min(sh), :min(sh)]
+    else:
+        square_image = image
+
+    return square_image
+
+
 class CropEfficiencyWarning(AstropyUserWarning):
     pass
 
@@ -161,12 +174,18 @@ class Hologram(object):
             Pixel width in x-direction (unbinned)
         dy : float [meters]
             Pixel width in y-direction (unbinned)
+
+        Notes
+        -----
+        Non-square holograms will be cropped to a square with the dimensions of
+        the smallest dimension.
         """
         self.crop_fraction = crop_fraction
         self.rebin_factor = rebin_factor
 
         # Rebin the hologram
-        binned_hologram = rebin_image(np.float64(hologram), self.rebin_factor)
+        square_hologram = _crop_to_square(np.float64(hologram))
+        binned_hologram = rebin_image(square_hologram, self.rebin_factor)
 
         # Crop the hologram by factor crop_factor, centered on original center
         if crop_fraction is not None:

--- a/shampoo/tests/test_hologram.py
+++ b/shampoo/tests/test_hologram.py
@@ -78,3 +78,15 @@ def test_multiple_reconstructions():
     # check hologram doesn't get modified again
     assert np.all(h_apodized1 == h_apodized2)
 
+
+def test_nonsquare_hologram():
+    sq_holo = _example_hologram()
+    nonsq_holo = sq_holo[:-10, :]
+
+    holo = Hologram(nonsq_holo)
+    w = holo.reconstruct(0.5)
+
+    phase_shape = w.phase.shape
+
+    assert phase_shape[0] == min(nonsq_holo.shape)
+    assert phase_shape[1] == min(nonsq_holo.shape)


### PR DESCRIPTION
Here's a temporary fix for #15. This crops a non-square hologram to a square with both dimensions of the cropped hologram equivalent to the smallest dimension of the original hologram.

This closes issue #15.
