### PR TITLE
Replace `shift_peak`, other enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.4
     - 3.5
 
 # Setting sudo to false opts in to Travis-CI container-based builds.

--- a/shampoo/reconstruction.py
+++ b/shampoo/reconstruction.py
@@ -378,9 +378,7 @@ class Hologram(object):
         digital_phase_mask = np.exp(-1j*self.wavenumber * field_curvature_mask)
 
         if plots:
-            print(smooth_phase_image)
             fig, ax = plt.subplots(1, 2, figsize=(14, 8))
-            #ax[0].imshow(unwrapped_phase_image, origin='lower')
             ax[0].imshow(smooth_phase_image, origin='lower')
             ax[1].imshow(field_curvature_mask, origin='lower')
             plt.show()
@@ -499,7 +497,8 @@ class Hologram(object):
             hologram near the real image.
         """
         margin = int(self.n*margin_factor)
-        abs_fourier_arr = np.abs(fourier_arr)[margin:-margin, margin:-margin]
+        #abs_fourier_arr = np.abs(fourier_arr)[margin:-margin, margin:-margin]
+        abs_fourier_arr = np.abs(fourier_arr)[margin:self.n//2, margin:-margin]
         spectrum_centroid = _find_peak_centroid(abs_fourier_arr,
                                                 gaussian_width=10) + margin
 

--- a/shampoo/reconstruction.py
+++ b/shampoo/reconstruction.py
@@ -31,6 +31,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.convolution import convolve_fft, MexicanHat2DKernel
 
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import ImageGrid
 
 # Try importing optional dependency PyFFTW for Fourier transforms. If the import
 # fails, import scipy's FFT module instead
@@ -378,9 +379,32 @@ class Hologram(object):
         digital_phase_mask = np.exp(-1j*self.wavenumber * field_curvature_mask)
 
         if plots:
-            fig, ax = plt.subplots(1, 2, figsize=(14, 8))
-            ax[0].imshow(smooth_phase_image, origin='lower')
-            ax[1].imshow(field_curvature_mask, origin='lower')
+
+            # Set up figure and image grid
+            fig = plt.figure(figsize=(12, 5))
+
+            grid = ImageGrid(fig, 111,
+                             nrows_ncols=(1, 2),
+                             axes_pad=0.15,
+                             share_all=True,
+                             cbar_location="right",
+                             cbar_mode="single",
+                             cbar_size="7%",
+                             cbar_pad=0.15,
+                             )
+
+            # Add data to image grid
+            for ax, arr, title in zip(grid,
+                                      [smooth_phase_image, field_curvature_mask],
+                                      ['smothed phase image', 'curvature fit']):
+                im = ax.imshow(arr, vmin=smooth_phase_image.min(),
+                               vmax=smooth_phase_image.max(),
+                               cmap=plt.cm.plasma, origin='lower',
+                               interpolation='nearest')
+                ax.set_title(title)
+            # Colorbar
+            ax.cax.colorbar(im)
+            ax.cax.toggle_label(True)
             plt.show()
 
         return digital_phase_mask


### PR DESCRIPTION
This PR encompasses four improvements: 

1. The `shift_peak` method described in #23 has been replaced with an `fftshift`-like method. I copied the numpy implementation and tweaked it so that it works for our purposes in the general case where the Fourier spectrum is not only being shifted to the center, but that the center can also be translated further. This should be a speedup over the older implementation, which called `np.roll` once per axis.

2. The Fourier peak detection algorithm on occasion picks out the virtual image rather than the real image. I can't figure out what causes it to go one way or the other – is the FFT not strictly deterministic? In any case, I've solved this problem here (at least temporarily) by enforcing that the image in Fourier space that gets selected as the real image must be in the fourth quadrant. This seems to reliably produce good reconstructions.

3. I made some tweaks to the aberration correction plots so that it's easier to interpret them, which will be handy if we try to improve those aberration corrections in the future.

4. I removed py3.4 from the testing matrix to save server time.

This closes #23.