### PR TITLE
Switching to pyfftw only

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -11,5 +11,6 @@ dependencies:
     - scikit-image
     - scikit-learn
     - pyfftw
+    - fftw
     - pip:
         - mst_clustering

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -10,7 +10,7 @@ dependencies:
     - numpy
     - scikit-image
     - scikit-learn
-    - pyfftw
     - fftw
     - pip:
         - mst_clustering
+        - pyfftw

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -10,5 +10,6 @@ dependencies:
     - numpy
     - scikit-image
     - scikit-learn
+    - pyfftw
     - pip:
         - mst_clustering

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='mst_clustering'
-        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5'
+        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 pyfftw'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
-        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 fftw'
-        - PIP_DEPENDENCIES='mst_clustering pyfftw'
-        - CONDA_CHANNELS='astropy-ci-extras astropy salilab'
+        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 fftw pyfftw'
+        - PIP_DEPENDENCIES='mst_clustering'
+        - CONDA_CHANNELS='astropy-ci-extras astropy salilab conda-forge'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='mst_clustering'
-        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 pyfftw fftw'
+        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 fftw'
+        - PIP_DEPENDENCIES='mst_clustering pyfftw'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='mst_clustering'
-        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 pyfftw'
+        - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 pyfftw fftw'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
         - SETUP_CMD='test'
         - CONDA_DEPENDENCIES='scipy h5py scipy matplotlib scikit-image scikit-learn hdf5 fftw'
         - PIP_DEPENDENCIES='mst_clustering pyfftw'
+        - CONDA_CHANNELS='astropy-ci-extras astropy salilab'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
       # Cython code, you can set CONDA_DEPENDENCIES=''
       CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn fftw"
       PIP_DEPENDENCIES: "mst_clustering pyfftw"
+      CONDA_CHANNELS: "astropy-ci-extras astropy salilab"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ environment:
       # For this package-template, we include examples of Cython modules,
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn pyfftw fftw"
-      PIP_DEPENDENCIES: "mst_clustering"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn fftw"
+      PIP_DEPENDENCIES: "mst_clustering pyfftw"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       # For this package-template, we include examples of Cython modules,
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn pyfftw fftw"
       PIP_DEPENDENCIES: "mst_clustering"
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ environment:
       # For this package-template, we include examples of Cython modules,
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn fftw"
-      PIP_DEPENDENCIES: "mst_clustering pyfftw"
-      CONDA_CHANNELS: "astropy-ci-extras astropy salilab"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn fftw pyfftw"
+      PIP_DEPENDENCIES: "mst_clustering"
+      CONDA_CHANNELS: "astropy-ci-extras astropy salilab conda-forge"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ environment:
       # For this package-template, we include examples of Cython modules,
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn fftw pyfftw"
-      PIP_DEPENDENCIES: "mst_clustering"
-      CONDA_CHANNELS: "astropy-ci-extras astropy salilab conda-forge"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx scipy matplotlib scikit-image astropy h5py scikit-learn fftw"
+      PIP_DEPENDENCIES: "mst_clustering pyfftw"
+      CONDA_CHANNELS: "astropy-ci-extras astropy salilab"
 
   matrix:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ class Mock(object):
         else:
             return Mock()
 
-MOCK_MODULES = ['pyfftw', 'h5py']
+MOCK_MODULES = ['h5py']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,9 +8,9 @@
 
 shampoo is an open source Python package for digital holographic
 microscopy with `SHAMU <http://www.caltech.edu/news/building-microscope-search-signs-life-other-worlds-48555>`_, 
-the Submersible Holographic Astrobiology Microscope with Ultraresolution. At present,
-shampoo does holographic reconstruction, and in the near future, shampoo will support
-specimen detection and tracking.
+the Submersible Holographic Astrobiology Microscope with Ultraresolution. At
+present, shampoo does holographic reconstruction, and in the near future,
+shampoo will support specimen detection and tracking.
 
 .. warning::
         This code is in development and may break without warning.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,9 +15,8 @@ Requirements
     excellent `Anaconda Python Distribution <http://continuum.io/downloads>`_
     which provides easy access to all of the above dependencies and more.
 
-**shampoo** works on Linux, Mac OS X and Windows.
-It requires Python 3.5+ or 2.7 (earlier versions are not
-supported) as well as the following packages:
+**shampoo** works on Linux, Mac OS X and Windows. It requires Python 3.5 or 2.7
+(earlier versions are not supported) as well as the following packages:
 
 * `Numpy`_
 * `scipy`_
@@ -26,12 +25,7 @@ supported) as well as the following packages:
 * `sklearn`_
 * `Astropy`_
 * `h5py`_
-
-Optional packages:
-
-* `pyfftw`_ - This package is **highly** recommended. It will speed up your FFT
-  computations by a factor of 2-3 for holograms with pixel dimensions
-  :math:`2^n` where :math:`n` is an integer.
+* `pyfftw`_
 
 
 Install shampoo

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,6 +27,16 @@ Requirements
 * `h5py`_
 * `pyfftw`_
 
+pyFFTW
+~~~~~~
+
+shampoo depends on a package called `pyfftw`_ for speedy, multithreaded
+Fourier transforms, which is easy to install on Mac OS X and linux but may be
+tricky on Windows machines. We recommend that Windows users install pyfftw by
+doing the following steps via conda::
+
+    conda install -c salilab fftw
+    pip install pyfftw
 
 Install shampoo
 ===============
@@ -40,6 +50,7 @@ repository::
 
     cd shampoo
     python setup.py install
+
 
 Testing
 =======

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(name=PACKAGENAME,
           docs=['sphinx_rtd_theme']
       ),
       install_requires=['numpy', 'scipy', 'astropy', 'scikit-image',
-                        'matplotlib', 'scikit-learn'],
+                        'matplotlib', 'scikit-learn', 'pyfftw'],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,

--- a/shampoo/__init__.py
+++ b/shampoo/__init__.py
@@ -9,3 +9,4 @@ if not _ASTROPY_SETUP_:
     from .store import *
     from .focus import *
     from .vis import *
+    from .fftutils import *

--- a/shampoo/fftutils.py
+++ b/shampoo/fftutils.py
@@ -1,0 +1,108 @@
+"""
+This module is a wrapper around ``pyfftw``'s API for fast Fourier transforms.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import pyfftw
+import numpy as np
+from numpy.compat import integer_types
+
+pyfftw.interfaces.cache.enable()
+
+__all__ = ['FFT', 'fftshift']
+
+
+class FFT(object):
+    """
+    Convenience wrapper around `~pyfftw.builders.fft2`.
+    """
+    def __init__(self, shape, float_precision, complex_precision, threads=2):
+        """
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the arrays which you will take the Fourier transforms of.
+        float_precision : `~numpy.dtype`
+        complex_precision : `~numpy.dtype`
+        threads : int, optional
+            This FFT implementation uses multithreading, with
+            two threads by default.
+        """
+        # Allocate byte-aligned
+        self.buffer_float = pyfftw.empty_aligned(shape,
+                                                 dtype=float_precision.__name__)
+        self.buffer_complex = pyfftw.empty_aligned(shape,
+                                                   dtype=complex_precision.__name__)
+        self._fft2 = pyfftw.builders.fft2(self.buffer_float, threads=threads)
+        self._ifft2 = pyfftw.builders.ifft2(self.buffer_complex,
+                                            threads=threads)
+
+    def fft2(self, array):
+        """
+        2D Fourier transform.
+
+        Parameters
+        ----------
+        array : `~numpy.ndarray`
+            Input array
+        """
+        self._fft2.input_array[:] = array
+        return self._fft2()
+
+    def ifft2(self, array):
+        """
+        Inverse 2D Fourier transform.
+
+        Parameters
+        ----------
+        array : `~numpy.ndarray`
+            Input array
+        """
+        self._ifft2.input_array[:] = array
+        return self._ifft2()
+
+
+def fftshift(x, additional_shift=None, axes=None):
+    """
+    Shift the zero-frequency component to the center of the spectrum, or with
+    some additional offset from the center.
+
+    This is a more generic fork of `~numpy.fft.fftshift`, which doesn't support
+    additional shifts.
+
+
+    Parameters
+    ----------
+    x : array_like
+        Input array.
+    additional_shift : list of length ``M``
+        Desired additional shifts in ``x`` and ``y`` directions respectively
+    axes : int or shape tuple, optional
+        Axes over which to shift.  Default is None, which shifts all axes.
+
+    Returns
+    -------
+    y : `~numpy.ndarray`
+        The shifted array.
+    """
+    tmp = np.asarray(x)
+    ndim = len(tmp.shape)
+    if axes is None:
+        axes = list(range(ndim))
+    elif isinstance(axes, integer_types):
+        axes = (axes,)
+
+    # If no additional shift is supplied, reproduce `numpy.fft.fftshift` result
+    if additional_shift is None:
+        additional_shift = [0, 0]
+
+    y = tmp
+    for k, extra_shift in zip(axes, additional_shift):
+        n = tmp.shape[k]
+        if (n+1)//2 - extra_shift < n:
+            p2 = (n+1)//2 - extra_shift
+        else:
+            p2 = abs(extra_shift) - (n+1)//2
+        mylist = np.concatenate((np.arange(p2, n), np.arange(0, p2)))
+        y = np.take(y, mylist, k)
+    return y

--- a/shampoo/tests/test_hologram.py
+++ b/shampoo/tests/test_hologram.py
@@ -2,10 +2,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..reconstruction import (Hologram, rebin_image, _find_peak_centroid,
-                              RANDOM_SEED, _crop_image, CropEfficiencyWarning)
+                              random_seed, _crop_image, CropEfficiencyWarning)
 
 import numpy as np
-np.random.seed(RANDOM_SEED)
+np.random.seed(random_seed)
 
 
 def _example_hologram(dim=2048):


### PR DESCRIPTION
After investigating FFT efficiency in #27, in this PR I'm switching to using `pyfftw` for FFTs only, without the `scipy` fallback option. This should speed reconstructions up.

The `pyfftw` API is a bit confusing, so I made a wrapper object for us. It works like this: 

```python
# Initialize an instance of the `FFT` object. Specifying the float and complex
# array precisions makes it efficient. Specify as many threads as you want to use.
fft = FFT(hologram_shape, float_precision, complex_precision, threads=2)

# Take the Fourier transform of `hologram`
result = fft.fft2(hologram)

# Take the inverse Fourier transform of `result`
recovered_hologram = fft.ifft2(result)
```

This closes #27 and #18.